### PR TITLE
feat(cli): Enhance hh-lab status command with comprehensive service monitoring

### DIFF
--- a/packer/scripts/hh-lab
+++ b/packer/scripts/hh-lab
@@ -119,6 +119,8 @@ check_k8s_deployment() {
     if [ -n "$label_selector" ]; then
         local ready_pods
         ready_pods=$(kubectl get pods -n "$namespace" -l "$label_selector" --field-selector=status.phase=Running 2>/dev/null | grep -c "Running" || echo "0")
+        # Ensure ready_pods is numeric before comparison
+        ready_pods="${ready_pods:-0}"
         if [ "$ready_pods" -gt 0 ]; then
             echo "running"
         else
@@ -128,6 +130,8 @@ check_k8s_deployment() {
         if kubectl get deployment -n "$namespace" "$deployment" &> /dev/null; then
             local available
             available=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.availableReplicas}' 2>/dev/null || echo "0")
+            # Ensure available is numeric before comparison (handles empty/null values)
+            available="${available:-0}"
             if [ "$available" -gt 0 ]; then
                 echo "running"
             else
@@ -244,8 +248,11 @@ cmd_status() {
             servers_running=$(echo "$servers_info" | cut -d/ -f1)
             local servers_total
             servers_total=$(echo "$servers_info" | cut -d/ -f2)
+            # Ensure values default to empty string if parsing fails
+            servers_running="${servers_running:-}"
+            servers_total="${servers_total:-}"
             # Check if all servers are running (X/X where X > 0)
-            if [ "$servers_running" = "$servers_total" ] && [ "$servers_total" != "0" ] && [ "$servers_total" != "" ]; then
+            if [ -n "$servers_running" ] && [ -n "$servers_total" ] && [ "$servers_running" = "$servers_total" ] && [ "$servers_total" != "0" ]; then
                 print_status_ok
             else
                 print_status_pending


### PR DESCRIPTION
Closes #15

## Summary

Enhanced the `hh-lab status` command to provide comprehensive monitoring of the Hedgehog Lab Appliance, including build type, service health for all key components, resource counts, and current scenario information.

## Acceptance Criteria Met

- [x] Shows build type (standard/prewarmed)
- [x] Lists service health (k3d, VLAB, ArgoCD, Gitea, Grafana, Prometheus)
- [x] Shows resource counts (switches, VPCs, K8s nodes)
- [x] Current scenario displayed
- [x] Color-coded status indicators ([OK], [FAIL], [PENDING])

## Implementation Details

### New Helper Functions
- **`check_k8s_deployment()`**: Checks Kubernetes deployment/pod status using label selectors
  - Handles namespace existence checks
  - Returns standardized status: running, not-deployed, not-ready, no-cluster, unknown
  - Works with both deployments and label selectors for pods

- **`get_vlab_resources()`**: Parses VLAB wiring.yaml to extract resource counts
  - Counts switches from the Switches section
  - Counts VPCs from the VPCs section
  - Returns "0 0" if wiring diagram not found

- **`get_current_scenario()`**: Reads current scenario from state file
  - Returns "default" if no scenario file exists
  - Supports future scenario management features

### Enhanced Status Output

The status command now displays information in organized sections:

1. **Initialization Status**
   - Shows if lab is initialized and ready
   - Displays build type (standard/prewarmed)
   - Shows initialization progress if in-progress

2. **Services Health**
   - k3d cluster (checks for k3d-observability cluster)
   - Kubernetes API connectivity
   - VLAB/hhfab (checks wiring.yaml and runs `hhfab vlab inspect`)
   - ArgoCD (checks argocd namespace and server pods)
   - Gitea (checks gitea namespace and pods)
   - Grafana (checks monitoring namespace and grafana pods)
   - Prometheus (checks monitoring namespace and prometheus pods)

3. **Lab Resources** (only shown when initialized)
   - Switch count from VLAB
   - VPC count from VLAB
   - Kubernetes node count

4. **Current Scenario**
   - Displays active scenario name

All status indicators use color-coding:
- **[OK]** - Green: Service is running and healthy
- **[FAIL]** - Red: Service has failed or is not responding
- **[PENDING]** - Yellow: Service not yet deployed or initializing

### Updated Help Text

Updated the `hh-lab help` output to reflect the enhanced capabilities of the status command.

## Testing

Tested on development environment:
- ✅ Script syntax validation passes (`bash -n`)
- ✅ Help text displays correctly
- ✅ Status command executes without errors
- ✅ Color-coded output renders properly
- ✅ Gracefully handles missing services/components

The enhanced status command will provide users with a comprehensive view of their lab environment at a glance, making it easy to verify that all components are running correctly.

## Example Output

```
Hedgehog Lab Status

✓ Lab is initialized and ready

  Initialized: 2025-11-04T10:00:00Z
  Build Type: standard

Services Health

  k3d cluster: [OK]
  Kubernetes API: [OK]
  VLAB (hhfab): [OK]
  ArgoCD: [OK]
  Gitea: [OK]
  Grafana: [OK]
  Prometheus: [OK]

Lab Resources

  Switches: 7
  VPCs: 2
  K8s Nodes: 3

Current Scenario

  Scenario: default

ℹ Run 'hh-lab logs' to view initialization logs
ℹ Run 'hh-lab info' for detailed system information
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)