### PR TITLE
docs(release): Update CHANGELOG.md for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Release process documentation with comprehensive checklists and guidelines
-- Changelog following Keep a Changelog format
-- Version numbering strategy using semantic versioning
 
 ### Changed
 
@@ -21,6 +18,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+---
+
+## [0.1.0] - 2025-11-05
+
+### Added
+- Standard build pipeline using Packer for Ubuntu 22.04 LTS base (#2, #4)
+- Automated orchestrator system with state machine for lab initialization (#7, #8)
+- Systemd service for automatic first-boot initialization (#9)
+- Terminal-based readiness UI showing real-time initialization progress (#10)
+- VLAB initialization with 7-switch Hedgehog Fabric topology (#11)
+- K3d cluster setup with observability stack (Prometheus, Grafana, Loki) (#12)
+- Lab management CLI tool (hh-lab) with status, logs, and reset commands (#14, #15)
+- Comprehensive user documentation including installation, quick start, troubleshooting, and FAQ (#17)
+- Automated build validation tests for verifying OVA integrity (#18)
+- End-to-end testing framework for validating complete builds (#21)
+- Release process documentation with comprehensive checklists and guidelines (#19)
+- GitHub Actions CI/CD workflow for standard builds (#5)
+
+### Changed
+- Build optimized for GitHub Actions runners with reduced resource allocation
+
+### Fixed
+- OVA compliance issues with disk capacity and manifest format
+- Packer password hash and network check issues
+- Orchestrator error handling and state management improvements
+- CLI argument parsing and status detection logic
+- VLAB resource counting to use Kubernetes YAML format
+- JSON parsing robustness in readiness UI
+- Test report generation on early failures
 
 ---
 


### PR DESCRIPTION
Closes #23

## Summary
Update CHANGELOG.md with v0.1.0 release information documenting all features, changes, and fixes included in the MVP release.

## Changes
- Add v0.1.0 release entry dated 2025-11-05
- Document all major features added in MVP:
  - Standard build pipeline
  - Orchestrator system with readiness UI
  - VLAB and K3d cluster setup
  - Lab management CLI (hh-lab)
  - Comprehensive documentation and testing
- Include all bug fixes and improvements
- Reset Unreleased section for future changes

## Testing
- Verified CHANGELOG.md follows Keep a Changelog format
- All issue references are accurate

## Next Steps
After this PR is merged:
1. Create git tag v0.1.0 on main branch
2. Push tag to trigger automated build workflow
3. GitHub Actions will create release with checksums
4. Enhance release notes with detailed information