### PR TITLE
fix(orchestrator): Improve build-type handling for graceful defaults

### DIFF
--- a/packer/scripts/hedgehog-lab-orchestrator
+++ b/packer/scripts/hedgehog-lab-orchestrator
@@ -127,12 +127,17 @@ BUILD_TYPE="standard"
 if [ -f "$BUILD_TYPE_FILE" ]; then
     BUILD_TYPE=$(cat "$BUILD_TYPE_FILE" | tr -d '[:space:]')
 fi
-log_info "Build type: $BUILD_TYPE"
 
-# Validate build type
+# Validate build type and default to standard if invalid
 if [[ ! "$BUILD_TYPE" =~ ^(standard|prewarmed)$ ]]; then
-    error "Invalid build type: $BUILD_TYPE (must be 'standard' or 'prewarmed')"
+    if [ -f "$BUILD_TYPE_FILE" ]; then
+        log_warn "Invalid build type in $BUILD_TYPE_FILE: '$BUILD_TYPE' (must be 'standard' or 'prewarmed')"
+        log_warn "Defaulting to 'standard' build type"
+    fi
+    BUILD_TYPE="standard"
 fi
+
+log_info "Build type: $BUILD_TYPE"
 
 # Helper function to execute a step with error handling
 execute_step() {

--- a/packer/scripts/hh-lab
+++ b/packer/scripts/hh-lab
@@ -185,11 +185,15 @@ cmd_status() {
     echo ""
 
     # Build Type and Initialization Status
-    local build_type="unknown"
+    local build_type="standard"
     local init_status="not-initialized"
 
     if [ -f "$BUILD_TYPE_FILE" ]; then
-        build_type=$(cat "$BUILD_TYPE_FILE")
+        build_type=$(cat "$BUILD_TYPE_FILE" | tr -d '[:space:]')
+        # Validate and default to standard if invalid
+        if [[ ! "$build_type" =~ ^(standard|prewarmed)$ ]]; then
+            build_type="standard"
+        fi
     fi
 
     if [ -f "$STAMP_FILE" ]; then
@@ -486,12 +490,15 @@ cmd_info() {
 
     # Build information
     print_header "Build Information"
+    local build_type="standard"
     if [ -f "$BUILD_TYPE_FILE" ]; then
-        local build_type=$(cat "$BUILD_TYPE_FILE")
-        print_label "  Build Type" "$build_type"
-    else
-        print_label "  Build Type" "unknown"
+        build_type=$(cat "$BUILD_TYPE_FILE" | tr -d '[:space:]')
+        # Validate and default to standard if invalid
+        if [[ ! "$build_type" =~ ^(standard|prewarmed)$ ]]; then
+            build_type="standard"
+        fi
     fi
+    print_label "  Build Type" "$build_type"
 
     if [ -f "$STAMP_FILE" ] && [ -r "$STAMP_FILE" ]; then
         local init_time=$(grep "initialized_at" "$STAMP_FILE" | sed 's/.*: "\([^"]*\)".*/\1/' || echo "unknown")


### PR DESCRIPTION
Closes #44

## Summary
This PR improves the build type detection logic to gracefully handle invalid or missing build type files by defaulting to 'standard' instead of erroring out. This ensures the system remains functional even when the build-type file is missing, corrupted, or contains invalid values.

## Changes Made

### Orchestrator (`hedgehog-lab-orchestrator`)
- **Before:** Would error out with `Invalid build type` and stop initialization
- **After:** Logs warning about invalid value and defaults to 'standard', allowing initialization to continue

### CLI Status Command (`hh-lab status`)
- **Before:** Displayed "unknown" for missing files, didn't validate values
- **After:** Defaults to 'standard' for missing/invalid files, validates and sanitizes values

### CLI Info Command (`hh-lab info`)
- **Before:** Displayed "unknown" for missing files, didn't validate values
- **After:** Defaults to 'standard' for missing/invalid files, validates and sanitizes values

### Additional Improvements
- All scripts now trim whitespace from build type values using `tr -d '[:space:]'`
- Consistent validation logic across all scripts using regex: `^(standard|prewarmed)$`

## Acceptance Criteria Met
- [x] Orchestrator reads `/etc/hedgehog-lab/build-type` file
- [x] Standard builds: value = `standard`, run full initialization
- [x] Pre-warmed builds: value = `prewarmed`, skip to service startup
- [x] Build type logged in initialization logs
- [x] Build type displayed in `hh-lab status` output
- [x] `hh-lab info` shows build type
- [x] Handle missing/invalid build-type file gracefully (default to standard)

## Testing

### Syntax Validation
✅ Both scripts pass bash syntax check (`bash -n`)

### Logic Testing
Created comprehensive test suite covering:
- ✅ Valid 'standard' build type
- ✅ Valid 'prewarmed' build type
- ✅ Invalid build type (defaults to 'standard')
- ✅ Missing file (defaults to 'standard')
- ✅ Whitespace handling (trimmed correctly)

All tests passed successfully.

## Implementation Notes

The issue acceptance criteria were already mostly implemented in the codebase. The main gap was in error handling:
- The orchestrator would **fail** on invalid build types instead of defaulting gracefully
- The CLI commands would show "unknown" instead of defaulting to "standard"

This PR fills that gap to ensure robust, graceful degradation.

## Related
- Epic: #38
- Reference: ADR-001 section on build type detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)