### PR TITLE
feat(installer): support GHCR credentials via environment variables

### DIFF
--- a/scripts/hh-lab-installer
+++ b/scripts/hh-lab-installer
@@ -17,8 +17,9 @@ REPO_ROOT="https://raw.githubusercontent.com/afewell-hh/labapp/main"
 STAGING_DIR="/tmp/packer-provisioner-shell-scripts"
 LOG_ROOT="/var/log/hedgehog-lab-installer"
 
-GHCR_USER=""
-GHCR_TOKEN=""
+# Check for environment variables first, then allow command-line args to override
+GHCR_USER="${GHCR_USER:-}"
+GHCR_TOKEN="${GHCR_TOKEN:-}"
 INTERACTIVE=false
 DRY_RUN=false
 


### PR DESCRIPTION
## Summary
Adds support for passing GHCR credentials via environment variables to enable automated testing while maintaining backward compatibility with command-line arguments.

## Problem
The `curl | bash -s -- --args` pattern has limitations when passing arguments through remote execution contexts. Command-line arguments passed via `--ghcr-user` and `--ghcr-token` don't reliably reach the script when piped through curl over SSH.

## Solution
Modified the installer to check for environment variables first, then allow command-line arguments to override:

```bash
# Before:
GHCR_USER=""
GHCR_TOKEN=""

# After:
# Check for environment variables first, then allow command-line args to override
GHCR_USER="${GHCR_USER:-}"
GHCR_TOKEN="${GHCR_TOKEN:-}"
```

This enables two credential passing methods:
- **Environment variables (for automation)**: `GHCR_USER=x GHCR_TOKEN=y curl URL | sudo -E bash`
- **Command-line arguments (for users)**: `bash script --ghcr-user=x --ghcr-token=y`

## Testing
Validated environment variable passing through SSH:
```bash
gcloud compute ssh test-vm --command="GHCR_USER=${GHCR_USERNAME} GHCR_TOKEN=${GHCR_TOKEN} bash -c 'echo User: \$GHCR_USER'"
```
Result: Successfully printed "User: hh-partner"

## Closes #97
