### PR TITLE
fix(vlab): restore VLAB readiness verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ test-unit: ## Run unit tests
 	@tests/unit/test-orchestrator-ordering.sh
 	@tests/unit/test-systemd-services.sh
 	@tests/unit/test-first-boot-setup.sh
+	@tests/unit/test-vlab-readiness.sh
 	@echo "Unit tests complete!"
 
 test-orchestrator: ## Run orchestrator unit tests only


### PR DESCRIPTION
## Summary
- restore hhfab VLAB launch to use --ready wait for built-in readiness verification
- add verify_switch_count post-start check using kubeconfig to confirm all 7 switches/nodes are registered
- add unit test guard to ensure readiness flag and verification logic stay in place

## Testing
- make test-unit
- make lint (fails on pre-existing shellcheck/yamllint issues outside this change; see console output)

Closes #104